### PR TITLE
Add master branch to coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
This pull request adds the master branch to also run under the coverage workflow.

I noticed the master branch is included on the test workflow but not for coverage.